### PR TITLE
Skip typedescs in nonIntrusiveBody

### DIFF
--- a/nesm.nim
+++ b/nesm.nim
@@ -84,7 +84,9 @@ proc cleanupTypeDeclaration(declaration: NimNode): NimNode =
   copyNimNode(declaration).add(children)
 
 macro nonIntrusiveBody(typename: typed, o: untyped, de: static[bool]): untyped =
-  let typebody = getTypeImpl(typename)
+  var typebody = getTypeImpl(typename)
+  while typebody.kind == nnkBracketExpr and typebody[0].eqIdent"typeDesc":
+    typebody = typebody[1]
   let ctx = getContext()
   when defined(debug):
     hint("Deserialize? " & $de)


### PR DESCRIPTION
As described in https://github.com/nim-lang/Nim/pull/22535, there is a Nim bug where generic parameters used in templates act like values of types rather than types themselves. Fixing this causes this macro to fail on calls from `nonIntrusiveTemplate` because it now provides a typedesc for the first argument and a complaint is made that serializing typedescs is not possible. To avoid this, skip the typedesc representation.