### PR TITLE
properly skip typedescs

### DIFF
--- a/nesm.nim
+++ b/nesm.nim
@@ -86,7 +86,7 @@ proc cleanupTypeDeclaration(declaration: NimNode): NimNode =
 macro nonIntrusiveBody(typename: typed, o: untyped, de: static[bool]): untyped =
   var typebody = getTypeImpl(typename)
   while typebody.kind == nnkBracketExpr and typebody[0].eqIdent"typeDesc":
-    typebody = typebody[1]
+    typebody = getTypeImpl(typebody[1])
   let ctx = getContext()
   when defined(debug):
     hint("Deserialize? " & $de)


### PR DESCRIPTION
Unfortunately the last PR (https://github.com/nim-lang/NESM/pull/1) was not sufficient for the bugfix in https://github.com/nim-lang/Nim/pull/22535, with this change it is, this time locally tested.